### PR TITLE
[fix] capitalization on Copy Rules

### DIFF
--- a/contents/copy/copy-rules.html
+++ b/contents/copy/copy-rules.html
@@ -8,7 +8,7 @@
 <section>
   <h2>Design Patterns</h2>
 
-  <h3>More vs Learn more</h3>
+  <h3>&ldquo;More&rdquo; vs &ldquo;Learn more&rdquo;</h3>
   <p>
     Use <em>More</em> to indicate an expanding text area, use <em>Learn more</em> to indicate a link to another screen or webpage.
   </p>
@@ -41,7 +41,7 @@
 </section>
 
 <section>
-  <h2>Capitalisation on Firefox for desktop</h2>
+  <h2>Capitalisation on Firefox for Desktop</h2>
 
   <h3>Title Case</h3>
   <p>


### PR DESCRIPTION
as discussed here: https://github.com/FirefoxUX/photon/commit/802c6e5f022c8030ce00b9c598afd9565965ee44#commitcomment-22332812