### PR TITLE
fix header links on homepage

### DIFF
--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -77,7 +77,7 @@ const Editor = React.createClass({
         e.id = newId;
         if (e.tagName != 'H1') {
           let linkTo = document.createElement('a');
-          linkTo.innerHTML = `<img src="../images/global/link-16.svg" />`;
+          linkTo.innerHTML = `<img src="/images/global/link-16.svg" />`;
           linkTo.href = `#${e.id}`;
           e.appendChild(linkTo);
         }


### PR DESCRIPTION
Fixes #51 

the homepage is on a different level than the other pages, so we can't attach the links as relative addresses.