### PR TITLE
Feature: Add feedback footer and send GA event on click

### DIFF
--- a/images/global/close-16.svg
+++ b/images/global/close-16.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="context-fill" d="M9.061 8l3.47-3.47a.75.75 0 0 0-1.061-1.06L8 6.939 4.53 3.47a.75.75 0 1 0-1.06 1.06L6.939 8 3.47 11.47a.75.75 0 1 0 1.06 1.06L8 9.061l3.47 3.47a.75.75 0 0 0 1.06-1.061z"></path>
+</svg>

--- a/images/global/stop-16.svg
+++ b/images/global/stop-16.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="context-fill" d="M9.414 8l5.293-5.293a1 1 0 0 0-1.414-1.414L8 6.586 2.707 1.293a1 1 0 0 0-1.414 1.414L6.586 8l-5.293 5.293a1 1 0 1 0 1.414 1.414L8 9.414l5.293 5.293a1 1 0 0 0 1.414-1.414z"></path>
+</svg>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -5,6 +5,7 @@ const React = require('react');
 const TableOfContents = React.createFactory(require('./TableOfContents.jsx'));
 const Editor = React.createFactory(require('./Editor.jsx'));
 const Footer = React.createFactory(require('./Footer.jsx'));
+const Feedback = React.createFactory(require('./Feedback.jsx'));
 
 const { connect } = require('react-redux');
 const { getPage } = require('./utilities.js');
@@ -21,6 +22,7 @@ const App = React.createClass({
       <TableOfContents/>
       <main className="order-0 order-1-l overflow-y-scroll-l w-100">
         <Editor/>
+         <Feedback/>
         <Footer/>
       </main>
     </div>);

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -22,7 +22,7 @@ const App = React.createClass({
       <TableOfContents/>
       <main className="order-0 order-1-l overflow-y-scroll-l w-100">
         <Editor/>
-         <Feedback/>
+        <Feedback/>
         <Footer/>
       </main>
     </div>);

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -95,7 +95,7 @@ const Editor = React.createClass({
       let header_list = document.createElement('ul');
       header_list.addEventListener('click', (e) => {
         if (e.target.tagName === "A") {
-          sendEvent('header-click', e.target.getAttribute('href'), window.location.pathname)
+          sendEvent('header-click', e.target.getAttribute('href').substring(1), window.location.pathname)
         }
       });
       header_list.classList.add('toc');

--- a/src/components/Feedback.jsx
+++ b/src/components/Feedback.jsx
@@ -1,0 +1,37 @@
+'use strict';
+
+const React = require('react');
+const { sendEvent } = require('./utilities.js');
+
+const Feedback = React.createClass({
+  displayName: 'Feedback',
+  handleClick: function (e) {
+    sendEvent('feedback-click', e.target.id, window.location.pathname);
+    if (e.target.id === 'thumbs-down') {
+      window.open('https://github.com/FirefoxUX/photon/issues','_blank');
+    }
+  },
+
+  render: function() {
+    return(
+      <div className="center mw7 ph3 mb4 mb5-l">
+        <div className="w-100 ba b--light-gray br2 ph3 pb1 flex-ns justify-between-ns items-center-ns">
+          <p className="mt0 mb3 mb0-ns lh-copy pt2-ns">{'Tell us, was the content of this page helpful?'}</p>
+          <p className="ma0">
+            <a className="mr3 no-underline f3 lh-copy dib pt2"
+                id="thumbs-up"
+                onClick={this.handleClick}
+            >{'👍'}
+          </a>
+            <a className="no-underline f3 lh-copy dib pt2"
+                id="thumbs-down"
+                onClick={this.handleClick}
+            >{'👎'}
+          </a>
+          </p>
+        </div>
+      </div>)
+  }
+});
+
+module.exports = Feedback;

--- a/src/components/Feedback.jsx
+++ b/src/components/Feedback.jsx
@@ -2,36 +2,66 @@
 
 const React = require('react');
 const { sendEvent } = require('./utilities.js');
+const { connect } = require('react-redux');
+const { changeFeedbackMessage } = require('./actions.js');
 
-const Feedback = React.createClass({
+const Feedback = connect(state => {
+  var {feedback_ask} = state.data;
+  return {feedback_ask};
+})(React.createClass({
   displayName: 'Feedback',
+  propTypes: {
+    dispatch: React.PropTypes.func,
+    feedback_ask: React.PropTypes.string
+  },
+
   handleClick: function (e) {
     sendEvent('feedback-click', e.target.id, window.location.pathname);
     if (e.target.id === 'thumbs-down') {
       window.open('https://github.com/FirefoxUX/photon/issues','_blank');
     }
+    changeFeedbackMessage(this.props.dispatch, false)
+  },
+
+  handleXClick: function () {
+    changeFeedbackMessage(this.props.dispatch, true)
   },
 
   render: function() {
     return(
       <div className="center mw7 ph3 mb4 mb5-l">
         <div className="w-100 ba b--light-gray br2 ph3 pb1 flex-ns justify-between-ns items-center-ns">
-          <p className="mt0 mb3 mb0-ns lh-copy pt2-ns">{'Tell us, was the content of this page helpful?'}</p>
-          <p className="ma0">
-            <a className="mr3 no-underline f3 lh-copy dib pt2"
-                id="thumbs-up"
-                onClick={this.handleClick}
-            >{'👍'}
-          </a>
-            <a className="no-underline f3 lh-copy dib pt2"
-                id="thumbs-down"
-                onClick={this.handleClick}
-            >{'👎'}
-          </a>
-          </p>
+          {this.props.feedback_ask &&
+            <div className="w-100 flex-ns justify-between-ns items-center-ns">
+              <p className="mt0 mb3 mb0-ns lh-copy pt2-ns"
+                  id="feedback-text"
+              >{'Tell us, was the content of this page helpful?'}</p>
+              <p className="ma0">
+                <a className="mr3 no-underline f3 lh-copy dib pt2"
+                    id="thumbs-up"
+                    onClick={this.handleClick}
+                >{'👍'}
+                </a>
+                <a className="no-underline f3 lh-copy dib pt2"
+                    id="thumbs-down"
+                    onClick={this.handleClick}
+                >{'👎'}
+                </a>
+              </p>
+          </div>
+        ||
+        <div className="w-100 tc flex-ns items-center-ns">
+          <span className="flex-auto b mt0 mb3 mb0-ns lh-copy pt2-ns"
+              id="feedback-text"
+          >{'Thank you for the feedback!'}</span>
+          <a className="close-feedback"
+              onClick={this.handleXClick}
+          ></a>
+        </div>
+        }
         </div>
       </div>)
   }
-});
+}));
 
 module.exports = Feedback;

--- a/src/components/Feedback.jsx
+++ b/src/components/Feedback.jsx
@@ -5,6 +5,10 @@ const { sendEvent } = require('./utilities.js');
 const { connect } = require('react-redux');
 const { changeFeedbackMessage } = require('./actions.js');
 
+const feedbackStyle = {
+  height: '50px'
+};
+
 const Feedback = connect(state => {
   var {feedback_ask} = state.data;
   return {feedback_ask};
@@ -30,7 +34,9 @@ const Feedback = connect(state => {
   render: function() {
     return(
       <div className="center mw7 ph3 mb4 mb5-l">
-        <div className="w-100 ba b--light-gray br2 ph3 pb1 flex-ns justify-between-ns items-center-ns">
+        <div className="w-100 ba b--light-gray br2 ph3 pb1 flex-ns justify-between-ns items-center-ns"
+            style={feedbackStyle}
+        >
           {this.props.feedback_ask &&
             <div className="w-100 flex-ns justify-between-ns items-center-ns">
               <p className="mt0 mb3 mb0-ns lh-copy pt2-ns"
@@ -51,7 +57,7 @@ const Feedback = connect(state => {
           </div>
         ||
         <div className="w-100 tc flex-ns items-center-ns">
-          <span className="flex-auto b mt0 mb3 mb0-ns lh-copy pt2-ns"
+          <span className="flex-auto mt0 mb3 mb0-ns lh-copy pt2-ns"
               id="feedback-text"
           >{'Thank you for the feedback!'}</span>
           <a className="close-feedback"

--- a/src/components/actions.js
+++ b/src/components/actions.js
@@ -40,7 +40,13 @@ function loadUrl(dispatch, url) {
   dispatch({type: 'URL', url: url});
 }
 
+function changeFeedbackMessage(dispatch, feedback_ask) {
+  // Put something innocuous in the text to indicate we're loading.
+  dispatch({type: 'FEEDBACK', feedback_ask: feedback_ask});
+}
+
 module.exports = {
   getContent: getContent,
-  loadUrl: loadUrl
+  loadUrl: loadUrl,
+  changeFeedbackMessage: changeFeedbackMessage
 };

--- a/src/components/store.js
+++ b/src/components/store.js
@@ -3,6 +3,7 @@
 const {sources, pages} = mungeSources(require('json!../../contents/index.json'));
 const { UPDATE_PATH } = require('redux-simple-router');
 const { parsePath } = require('./utilities.js');
+const default_feedback_ask = true;
 
 function mungeSources(sources) {
   let pages = []
@@ -24,7 +25,8 @@ function store(state, action) {
       pages: pages,
       text: '',
       file: '',
-      url: ''};
+      url: '',
+      feedback_ask: default_feedback_ask};
   }
   switch (action.type) {
   case "@@router/INIT_PATH":
@@ -38,9 +40,11 @@ function store(state, action) {
       // Previous fetch completed, ignore it.
       return state;
     }
-    return Object.assign({}, state, {text: action.text || '', file: action.file});
+    return Object.assign({}, state, {text: action.text || '', file: action.file, feedback_ask: default_feedback_ask});
   case 'URL':
     return Object.assign({}, state, {url: action.url || ''});
+  case 'FEEDBACK':
+    return Object.assign({}, state, {feedback_ask: action.feedback_ask});
   default:
     return state;
   }

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -51,8 +51,8 @@ function sendPageview(url, hash) {
   }
 }
 
-function sendEvent(category, hash, url) {
-  ga('send', 'event', category, hash.substring(1), url);
+function sendEvent(category, action, url) {
+  ga('send', 'event', category, action, url);
 }
 
 module.exports = {PREFIX, getPage, parsePath, getUrl, getSiblingPages, sendPageview, sendEvent};

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -5,6 +5,14 @@
   write plain HTML without worrying about CSS classes.
 */
 
+/* Defaults */
+
+a {
+  color: var(--blue-50);
+  cursor: pointer;
+  text-decoration: none;
+}
+
 /* Click to copy tooltip */
 
 code {
@@ -86,12 +94,6 @@ main header {
   li ul {
     padding-left: 1rem;
     padding-top: 1rem;
-  }
-
-  a {
-    color: var(--blue-50);
-    cursor: pointer;
-    text-decoration: none;
   }
 
   @media screen and (min-width: 60em) {

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -307,3 +307,12 @@ main section article {
   height: 16px;
   width: 16px;
 }
+
+.close-feedback {
+  background-image: url("../../images/global/stop-16.svg");
+  background-repeat: no-repeat;
+  display: inline-block;
+  height: 16px;
+  margin-top: 8px;
+  width: 16px;
+}

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -313,6 +313,6 @@ main section article {
   background-repeat: no-repeat;
   display: inline-block;
   height: 16px;
-  margin-top: 8px;
+  margin-top: 4px;
   width: 16px;
 }


### PR DESCRIPTION
note: You probably want to add some visual feedback when the user clicks one of the buttons and /or remove the feedback element from the page after click.

On click, both of them sends an event to GA containing 
`Event Category = "feedback-click", Event Action = "thumbs-up" and Event Label = "/visual/illustration.html"`
for example.

Thumbs down opens a new tab with the github issues page (so the user does not have to log in).
