### PR TITLE
[fix] typo "Deafult" -> "Default"

### DIFF
--- a/contents/includes/components/buttons/buttons-behaviors-default.html
+++ b/contents/includes/components/buttons/buttons-behaviors-default.html
@@ -10,7 +10,7 @@
       </thead>
       <tbody>
         <tr>
-          <td>Deafult</td>
+          <td>Default</td>
           <td><code>#0c0c0d</code></td>
           <td>10%</td>
         </tr>

--- a/contents/includes/components/buttons/buttons-behaviors-primary.html
+++ b/contents/includes/components/buttons/buttons-behaviors-primary.html
@@ -9,7 +9,7 @@
       </thead>
       <tbody>
         <tr>
-          <td>Deafult</td>
+          <td>Default</td>
           <td><code>#0060df</code></td>
         </tr>
         <tr>


### PR DESCRIPTION
Hello, there was a typo in one of your pages - http://design.firefox.com/photon/components/buttons.html

<img width="772" alt="screen shot 2017-09-27 at 9 12 39 pm" src="https://user-images.githubusercontent.com/498909/30915213-a8bac496-a3c8-11e7-8dbc-4d17ea5c2484.png">

<img width="751" alt="screen shot 2017-09-27 at 9 13 12 pm" src="https://user-images.githubusercontent.com/498909/30915229-b7894646-a3c8-11e7-91fa-b4d8d0c8ceae.png">