### PR TITLE
Change "green" to "blue" in text to match image

### DIFF
--- a/contents/visuals/typography.html
+++ b/contents/visuals/typography.html
@@ -156,7 +156,7 @@
   
   <figure>
     <img src="../images/typography/linelength.svg" alt="line length">
-    <figcaption>Line lengths within the light green range are satisfactory, while entering the dark green range are tolerant.</figcaption>
+    <figcaption>Line lengths within the light blue range are satisfactory, while entering the dark blue range are tolerant.</figcaption>
   </figure>
 
 </section>


### PR DESCRIPTION
The image shows optimal line lengths in blue, while the copy refers to them as `green`.

https://www.evernote.com/l/AAp92Re7oX1JnpQMC67fyHXPja91NjKqqy4B/image.png