### PR TITLE
[fix] swapped text, bad grammar, invalid HTML in Errors

### DIFF
--- a/contents/includes/patterns/errors/system-errors.html
+++ b/contents/includes/patterns/errors/system-errors.html
@@ -1,21 +1,20 @@
 <div class="cf nr2 nl2">
   <div class="fl-ns w-50-ns ph2">
     <p>
-      User input error occurs when Firefox doesn't understand user inputs.
+      System errors occur when Firefox fails for some reason most likely not related to the user.
     </p>
-    <p>The most common cases are:
-      <ul>
+    <p>The most common cases are:</p>
+    <ul>
       <li>
-          Misspelled errors
-        </li>
-        <li>
-          Connettivity issues
-        </li>
-        <li>
-          Failure to load
-        </li>
-      </ul>
-    </p>
+        Misspelled errors
+      </li>
+      <li>
+        Connectivity issues
+      </li>
+      <li>
+        Failure to load
+      </li>
+    </ul>
   </div>
   <div class="fl-ns w-50-ns ph2">
     <figure>

--- a/contents/includes/patterns/errors/user-input-errors.html
+++ b/contents/includes/patterns/errors/user-input-errors.html
@@ -1,7 +1,7 @@
 <div class="cf nr2 nl2">
   <div class="fl-ns w-50-ns ph2">
     <p>
-      System errors occurs when Firefox fails for some reasons most likely not related to the user.
+      User input errors occur when Firefox doesn’t understand user inputs.
     </p>
     <p>The most common cases are:</p>
     <ul>


### PR DESCRIPTION
Affects http://design.firefox.com/photon/patterns/errors.html

- description of user and system errors was swapped
- fixed grammar in those descriptions
- fixed typo ‘Connettivity’
- moved `<ul>` element out of `<p>`, because `<p>` can’t contain flow content
- added ‘a’ to a user input error example to make the phrase easier to parse

There’s one more problem in this section that I'm not sure how to fix: it's not clear to me what the "Misspelled errors" example of a system error means. Does it mean a user error where the user spelled something wrong, i.e. spelling corrections? Or does it mean an error where the system crashes because it tried to display a different error dialog but misspelled the name of that dialog? Neither case makes much sense.

I would delete that example and replace it with something else, but I'm not sure what other examples of system errors I could put. If my reviewer doesn't know how to fix that example either, we could still merge these changes and file a separate issue about that.