### PR TITLE
send GA event when toggling between image and interactive example

### DIFF
--- a/contents/components/radio-buttons.html
+++ b/contents/components/radio-buttons.html
@@ -140,12 +140,14 @@
       <img src="../images/components/radio-buttons/radiobutton-states.svg" alt="Example of a selected and an unselected radio button." id="showImage">
       <iframe class="db w-100" height="180" src="https://designakt.github.io/PDS/components/radio-buttons/behavior.html" allowfullscreen="allowfullscreen" frameborder="0" id="showExample" style="display: none;"></iframe>
       <small class="db grey-50 mb3 mb0-ns">
-         <a href="#" onclick="document.getElementById('showImage').style.display='block';
-                              document.getElementById('showExample').style.display='none';
-                              return false;">Image</a> /
-         <a href="#" onclick="document.getElementById('showImage').style.display='none';
-                              document.getElementById('showExample').style.display='block';
-                              return false;">Interactive example</a> (Currently only renders correctly in Firefox.)
+        <div class='interactive'>
+          <a href="#" class="image-toggle" onclick="document.getElementById('showImage').style.display='block';
+                             document.getElementById('showExample').style.display='none';
+                             return false;">Image</a> /
+          <a href="#" class="interactive-toggle" onclick="document.getElementById('showImage').style.display='none';
+                             document.getElementById('showExample').style.display='block';
+                             return false;">Interactive example</a> (Currently only renders correctly in Firefox.)
+        </div>
       </small>
     </div>
     <div class="fl-ns w-50-ns ph2">

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -8,7 +8,7 @@ require('../../node_modules/highlight.js/styles/color-brewer.css');
 const React = require('react');
 const { connect } = require('react-redux');
 const ReactDOM = require('react-dom');
-const { getPage } = require('./utilities.js');
+const { getPage, sendEvent } = require('./utilities.js');
 
 const Editor = React.createClass({
   displayName: 'Editor',
@@ -39,6 +39,7 @@ const Editor = React.createClass({
   componentDidUpdate: function(prevProps) {
     if (prevProps.text !== this.props.text) {
       this.addIds();
+      this.addInteractionEvents();
       const page = this.props.page;
       let title = `${page.title} | Photon Design System`;
       if(page.category !== page.title) {
@@ -59,6 +60,20 @@ const Editor = React.createClass({
         element.classList.remove('blue-60');
       }, 1000);
     }
+  },
+
+  addInteractionEvents: function() {
+    let node = ReactDOM.findDOMNode(this);
+    let interactiveElements = Array.from(node.querySelectorAll('.interactive'));
+    interactiveElements.forEach(element => {
+      element.addEventListener('click', e => {
+        if (e.target.classList.contains('interactive-toggle')) {
+          sendEvent('click', 'interactive-toggle', window.location.pathname);
+        } else if (e.target.classList.contains('image-toggle')) {
+          sendEvent('click', 'image-toggle', window.location.pathname);
+        }
+      });
+    });
   },
 
   addIds: function () {

--- a/src/components/utilities.js
+++ b/src/components/utilities.js
@@ -51,7 +51,7 @@ function getSiblingPages(page, pages) {
   var current_index = shown_pages.indexOf(page);
   var previous_page = shown_pages[current_index - 1] || shown_pages[shown_pages.length - 1];
   var next_page = shown_pages[current_index + 1] || shown_pages[0];
-  return { previous_page, next_page }
+  return { previous_page, next_page };
 }
 
 function sendPageview(url, hash) {


### PR DESCRIPTION
send GA event when toggling between image and interactive example.
The event gets sent as a "click" event. type = 'interactive-toggle' or 'image-toggle', and the url of the page gets sent along too.

Fixes:  #251.