### PR TITLE
track interaction with focus example

### DIFF
--- a/contents/components/radio-buttons.html
+++ b/contents/components/radio-buttons.html
@@ -213,7 +213,27 @@
   <h4>Focused</h4>
   <div class="cf nr2 nl2">
     <div class="fl-ns w-50-ns ph2 mb3">
-      <iframe class="db w-100" height="180" src="https://designakt.github.io/PDS/components/radio-buttons/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
+      <div class="interactive">
+        <div id="focus-example" class="interactive-example">
+          <div class="container-demo">
+            <div class="radiobutton-wrapper">
+              <span>When Nightly Starts</span>
+              <div class="group-radio-buttons">
+                <input name="group2" class="track-clicks" id="radio-focus-1" checked="" type="radio">
+                <label for="radio-focus-1">Show your home page</label>
+              </div>
+              <div class="group-radio-buttons">
+                <input name="group2" class="track-clicks" id="radio-focus-2" type="radio">
+                <label for="radio-focus-2">Show a blank page</label>
+              </div>
+              <div class="group-radio-buttons">
+                <input name="group2" class="track-clicks" id="radio-focus-3" type="radio">
+                <label for="radio-focus-3">Show your windows and tabs from last time</label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
       <figcaption>
         Interactive example (Currently only renders correctly in Firefox.)
       </figcaption>

--- a/src/styles/page.scss
+++ b/src/styles/page.scss
@@ -526,4 +526,16 @@ div[data-tabs] input[type="radio"]:checked + label + div[data-tab] {
   input[type="radio"]:checked:hover:active {
     background-color: var(--blue-80);
   }
+
+  #focus-example label {
+    font-size: 13px;
+  }
+
+  .radiobutton-wrapper span {
+    display: inline-block;
+    font-size: 1.25em;
+    font-weight: bold;
+    line-height: 1.25em;
+    margin-bottom: 8px;
+  }
 }


### PR DESCRIPTION
tracking clicks on focus example.
removed the iframe.
I'm not tracking "focus" events for now, just clicks. I figure click will happen more often, and focus does not bubble, so the listener needs to be assigned to each element individually. We can speak about adding this later if you want that information. 