### PR TITLE
Remove trailing slash from GitHub URLs

### DIFF
--- a/contents/introduction/getting-started.html
+++ b/contents/introduction/getting-started.html
@@ -15,7 +15,7 @@
     With your help we will review any new UI to ensure Photon stays up to date, new components are added and existing ones are updated.
   </p>
   <p>
-    If you are missing information in Photon, please <a href="https://github.com/FirefoxUX/photon/issues/">file an issue</a> for it. This can be a component you notice that is not specified or a type of information that would make your work more productive.
+    If you are missing information in Photon, please <a href="https://github.com/FirefoxUX/photon/issues">file an issue</a> for it. This can be a component you notice that is not specified or a type of information that would make your work more productive.
   </p>
   <p>
     And if you want to help us grow Photon <a href="https://github.com/FirefoxUX/photon/wiki/Getting-Started">check out the wiki</a>.

--- a/contents/resources/colors.html
+++ b/contents/resources/colors.html
@@ -90,7 +90,7 @@
           <img class="mb0" src="../images/resources/sketch.svg" alt="Sketch logo">
         </a>
         <figcaption>
-          <a class="" href="https://firefoxux.github.io/design-tokens/photon-colors/photon-colors.sketchpalette" download>Sketch</a> used together with the <a class="" href="https://github.com/andrewfiorillo/sketch-palettes/">Sketch Palettes</a> plugin.
+          <a class="" href="https://firefoxux.github.io/design-tokens/photon-colors/photon-colors.sketchpalette" download>Sketch</a> used together with the <a class="" href="https://github.com/andrewfiorillo/sketch-palettes">Sketch Palettes</a> plugin.
         </figcaption>
       </figure>
     </div>

--- a/contents/visuals/illustration.html
+++ b/contents/visuals/illustration.html
@@ -49,7 +49,7 @@
 <section>
   <h2>Appearance</h2>
   <p>
-    Firefox illustrations are created for specific contexts and purposes. They should not be used in any other way without consulting the <a href="https://github.com/FirefoxUX/photon/issues/" alt="Request a new illustration by filling an issue">Content Team</a> first.
+    Firefox illustrations are created for specific contexts and purposes. They should not be used in any other way without consulting the <a href="https://github.com/FirefoxUX/photon/issues" alt="Request a new illustration by filling an issue">Content Team</a> first.
   </p>
   <h3>Background</h3>
   <p>
@@ -65,6 +65,6 @@
   </p>
   <h3>Customization</h3>
   <p>
-    Firefox illustrations should not be altered in any way, nor should they be combined with any other graphics, without the consent of the  <a href="https://github.com/FirefoxUX/photon/issues/">Content Team</a>.
+    Firefox illustrations should not be altered in any way, nor should they be combined with any other graphics, without the consent of the  <a href="https://github.com/FirefoxUX/photon/issues">Content Team</a>.
   </p>
 </section>

--- a/contents/welcome.html
+++ b/contents/welcome.html
@@ -34,7 +34,7 @@
         Share with us
       </p>
       <p>
-        <a href="https://github.com/firefoxux/photon/issues/">Share with us</a> so we can add or improve components and patterns.
+        <a href="https://github.com/firefoxux/photon/issues">Share with us</a> so we can add or improve components and patterns.
       </p>
     </div>
 
@@ -46,7 +46,7 @@
         File an issue
       </p>
       <p>
-        <a href="https://github.com/firefoxux/photon/issues/">Let us know</a> if we are missing components or our advice isn’t clear and actionable.
+        <a href="https://github.com/firefoxux/photon/issues">Let us know</a> if we are missing components or our advice isn’t clear and actionable.
       </p>
     </div>
 

--- a/src/components/TableOfContents.jsx
+++ b/src/components/TableOfContents.jsx
@@ -103,7 +103,7 @@ const TableOfContents = React.createClass({
           <div className="pb3 pb4-l">
             <p className="lh-copy mt0 mb1 fw4 f6">
               <a className="blue-60 no-underline"
-                  href="https://github.com/FirefoxUX/photon/issues/"
+                  href="https://github.com/FirefoxUX/photon/issues"
               >{'Site Feedback'}
               </a>
             </p>


### PR DESCRIPTION
This PR removes the trailing slash from all GitHub URLs, as GitHub doesn’t use trailing slashes.