### PR TITLE
Fix the colors of the generic message bar button

### DIFF
--- a/jekyll/_includes/components/message-bars/style-generic.md
+++ b/jekyll/_includes/components/message-bars/style-generic.md
@@ -10,11 +10,11 @@
 
 ##### BUTTONS
 
-Default: Blue 60 `#0a84ff`
+Default: Grey 90 a10 `rgba(12, 12, 13, 0.1)`
 
-Hover: Blue 70 `#0060df`
+Hover: Grey 90 a20 `rgba(12, 12, 13, 0.2)`
 
-Pressed: Blue 80 `#003eaa`
+Pressed: Grey 90 a30 `rgba(12, 12, 13, 0.3)`
 </div>
 </div>
 


### PR DESCRIPTION
The preview at `jekyll/images/message-bars/c-gen.svg` shows grey buttons (=default button style), which looks reasonable. However, the label in the image and the document's description specified a blue style that is meant to be used for the primary button.

This commit fixes the discrepancy by using the colors of the button as specified `_includes/components/buttons/behaviors-default.md` , and matches the rendered message bar (c-gen.svg).

TODO: Change "Blue-60" to "Grey-90-a10" at jekyll/images/message-bars/c-gen.svg
(I didn't change it here because those letters are a path in the vector image and not easily editable.)