### PR TITLE
Deploy sunset banner

### DIFF
--- a/jekyll/_includes/header.html
+++ b/jekyll/_includes/header.html
@@ -1,4 +1,4 @@
-<aside class="sunset-banner"><p>Photon has been retired since our <a title="Firefox June 2021 release notes" href="https://www.mozilla.org/en-US/firefox/89.0/releasenotes/">2021 design refresh release</a>. This project is no longer maintained and will no longer be updated. A new site for the Firefox design system will replace this in the future.</p></aside>
+<aside class="sunset-banner"><p>Photon has been retired since our <a title="Firefox June 2021 release notes" href="https://www.mozilla.org/en-US/firefox/89.0/releasenotes/">2021 design refresh release</a>. This site is no longer maintained and will no longer be updated. A new site for the Firefox design system will replace this in the future.</p></aside>
 <header class="site-header">
   <div class="wrapper">
     <a class="site-title" href="{{ site.baseurl }}/">{{ site.title }}</a>

--- a/jekyll/_includes/header.html
+++ b/jekyll/_includes/header.html
@@ -1,3 +1,4 @@
+<div class="sunset-banner">Photon has been retired since our <a title="June 2021 Release Notes" href="https://www.mozilla.org/en-US/firefox/89.0/releasenotes/?source=techstories.org">design refresh release in June 2021</a>. This project is no longer maintained and will no longer be updated.</div>
 <header class="site-header">
   <div class="wrapper">
     <a class="site-title" href="{{ site.baseurl }}/">{{ site.title }}</a>

--- a/jekyll/_includes/header.html
+++ b/jekyll/_includes/header.html
@@ -1,4 +1,4 @@
-<div class="sunset-banner">Photon has been retired since our <a title="June 2021 Release Notes" href="https://www.mozilla.org/en-US/firefox/89.0/releasenotes/?source=techstories.org">design refresh release in June 2021</a>. This project is no longer maintained and will no longer be updated.</div>
+<div class="sunset-banner">Photon has been retired since our <a title="June 2021 Release Notes" href="https://www.mozilla.org/en-US/firefox/89.0/releasenotes/">2021 design refresh release</a>. This project is no longer maintained and will no longer be updated. A new site for the Firefox design system will replace this in the future.</div>
 <header class="site-header">
   <div class="wrapper">
     <a class="site-title" href="{{ site.baseurl }}/">{{ site.title }}</a>

--- a/jekyll/_includes/header.html
+++ b/jekyll/_includes/header.html
@@ -1,4 +1,4 @@
-<div class="sunset-banner">Photon has been retired since our <a title="June 2021 Release Notes" href="https://www.mozilla.org/en-US/firefox/89.0/releasenotes/">2021 design refresh release</a>. This project is no longer maintained and will no longer be updated. A new site for the Firefox design system will replace this in the future.</div>
+<aside class="sunset-banner"><p>Photon has been retired since our <a title="Firefox June 2021 release notes" href="https://www.mozilla.org/en-US/firefox/89.0/releasenotes/">2021 design refresh release</a>. This project is no longer maintained and will no longer be updated. A new site for the Firefox design system will replace this in the future.</p></aside>
 <header class="site-header">
   <div class="wrapper">
     <a class="site-title" href="{{ site.baseurl }}/">{{ site.title }}</a>

--- a/jekyll/_sass/_colors.scss
+++ b/jekyll/_sass/_colors.scss
@@ -676,5 +676,6 @@
 .sunset-banner {
   background: $yellow-50;
   font-size: 16px;
+  font-weight: 600;
   padding: 24px;
 }

--- a/jekyll/_sass/_colors.scss
+++ b/jekyll/_sass/_colors.scss
@@ -672,3 +672,9 @@
     }
   }  
 }
+
+.sunset-banner {
+  background: $yellow-50;
+  font-size: 16px;
+  padding: 24px;
+}

--- a/jekyll/_sass/_colors.scss
+++ b/jekyll/_sass/_colors.scss
@@ -675,7 +675,16 @@
 
 .sunset-banner {
   background: $yellow-50;
+  border-bottom: 1px solid $yellow-70;
   font-size: 16px;
   font-weight: 600;
   padding: 24px;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+
+  p {
+    margin: 0;
+    padding: 0;
+  }
 }


### PR DESCRIPTION
## About
This pull request introduces a banner that communicates to visitors that Photon has been sunset since our 2021 release.

## Preview
_Latest as of Mon Aug 15_
<img width="2560" alt="Screen Shot 2022-08-15 at 10 51 32" src="https://user-images.githubusercontent.com/7318958/184669620-94df7dfa-2328-4c8f-a68e-d62e5ccec934.png">


## Need feedback

- [x] What do we write in the banner? I currently link us to our [89 release notes](https://www.mozilla.org/en-US/firefox/89.0/releasenotes/?source=techstories.org) that explain the design refresh.
_Discussed as a team and resolved copy._

- [x] Would be nice to perhaps offer some sort of resolution such as "new site coming soon" and perhaps our email.
_Added to the existing copy._

- [x] Also - the footer in the Photon site has a contact email that our team does not use. Perhaps let's take that into consideration as well.
_Decided to not fix anything else in the site._
