### PR TITLE
Add an updated deprecation notice directing to Acorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Photon Design System
 
-This project is no longer maintained or worked on. More to come soon on our next design system documentation website.
+Photon is Mozilla's previous, now deprecated, design system that documented UI from before V89. It is no longer in use and was replaced by [Acorn](https://acorn.firefox.com/).
 
 # Running Photon
 


### PR DESCRIPTION
Updates the README.md to point to Mozilla's current design system, instead of a generic deprecation notice. When searching for Mozilla's design system, this repository is likely to come up, so this change would be helpful to those looking for Acorn. Wording is modified slightly from https://acorn.firefox.com/latest/f-a-q-g56QlqB6:

> [Photon](https://firefoxux.github.io/photon/) [design system]
Our previous, now deprecated, design system that documented UI from before V89. It is no longer in use and was replaced by Acorn.